### PR TITLE
Use class definition for auto doc generation

### DIFF
--- a/docs/components/SimpleCard.md
+++ b/docs/components/SimpleCard.md
@@ -1,0 +1,11 @@
+---
+id:SimpleCard
+title:SimpleCard
+---
+Renders a placeholder element for the single-element payment form. The SqPaymentForm JS library will replace this element with
+a secure `<iframe>` tag that will render a form.
+
+When accepting credit card payments, you **must** have this component inside your `SquarePaymentForm`.
+
+Cannot be used with digital wallets
+

--- a/src/components/SimpleCard.tsx
+++ b/src/components/SimpleCard.tsx
@@ -9,6 +9,10 @@ import { ContextConsumer } from './Context'
  *
  * Cannot be used with digital wallets
  */
-export default function Card(): React.ReactElement {
-  return <ContextConsumer>{context => <div id={`${context.formId}-sq-card`}></div>}</ContextConsumer>
+class SimpleCard extends React.Component {
+  render(): React.ReactElement {
+    return <ContextConsumer>{context => <div id={`${context.formId}-sq-card`}></div>}</ContextConsumer>
+  }
 }
+
+export default SimpleCard

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -32,6 +32,9 @@
       "components/MasterpassButton": {
         "title": "MasterpassButton"
       },
+      "components/SimpleCard": {
+        "title": "SimpleCard"
+      },
       "components/SquarePaymentForm": {
         "title": "SquarePaymentForm"
       },
@@ -46,6 +49,9 @@
       },
       "production": {
         "title": "Taking payments in production"
+      },
+      "simplecard": {
+        "title": "Single-Element Payment Form"
       }
     },
     "links": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -9,6 +9,7 @@
       "components/CreditCardPostalCodeInput",
       "components/GooglePayButton",
       "components/MasterpassButton",
+      "components/SimpleCard",
       "components/SquarePaymentForm"
     ]
   }


### PR DESCRIPTION
We will eventually migrate to React hooks, but for now we are relying on "React.Component" to automatically generate the component documentation.