### PR TITLE
Append Square payments script if not exists

### DIFF
--- a/src/components/SquarePaymentForm.tsx
+++ b/src/components/SquarePaymentForm.tsx
@@ -184,11 +184,12 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
   }
 
   function loadSqPaymentFormLibrary(onSuccess?: () => void, onError?: () => void): void {
-    if (typeof SqPaymentForm === 'function') {
+    if (document.getElementById('sq-payment-form-script') && typeof SqPaymentForm === 'function') {
       onSuccess && onSuccess();
       return;
     }
     const script = document.createElement('script');
+    script.id = 'sq-payment-form-script';
     if (props.sandbox) {
       script.src = 'https://js.squareupsandbox.com/v2/paymentform';
     } else {
@@ -200,17 +201,6 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
     script.onerror = function() {
       onError && onError();
     };
-
-    let scriptExists = false;
-    const scripts = document.getElementsByTagName('script');
-    for (let i = scripts.length; i > 0; i--) {
-      if (scripts[i].src === script.src) {
-        scriptExists = true;
-      }
-    }
-    if (scriptExists) {
-      document.body.appendChild(script);
-    }
   }
 
   function buildSqPaymentFormConfiguration(props: Props): SqPaymentFormConfiguration {

--- a/src/components/SquarePaymentForm.tsx
+++ b/src/components/SquarePaymentForm.tsx
@@ -200,7 +200,17 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
     script.onerror = function() {
       onError && onError();
     };
-    document.body.appendChild(script);
+
+    let scriptExists = false;
+    const scripts = document.getElementsByTagName('script');
+    for (let i = scripts.length; i > 0; i--) {
+      if (scripts[i].src === script.src) {
+        scriptExists = true;
+      }
+    }
+    if (scriptExists) {
+      document.body.appendChild(script);
+    }
   }
 
   function buildSqPaymentFormConfiguration(props: Props): SqPaymentFormConfiguration {


### PR DESCRIPTION
If the Square Payments Javascript library is loaded more than once, it will result in a `ElementNotVisibleError` for all the form fields. This is not an issue if your parent component is only rendered once. But if it is re-rendered for any reason, the Square payment form component will re-insert the payment script and break the form.