### PR TITLE
Append sq payment form script to document

### DIFF
--- a/src/components/SquarePaymentForm.tsx
+++ b/src/components/SquarePaymentForm.tsx
@@ -213,6 +213,7 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
     script.onerror = function() {
       onError && onError();
     };
+    document.body.appendChild(script);
   }
 
   function buildSqPaymentFormConfiguration(props: Props): SqPaymentFormConfiguration {


### PR DESCRIPTION
Resolves #81 

The Square payment form library script was not being appended to the document which prevented the form to load. This PR adds back what was previously there to add the script to the document.