### PR TITLE
Always call default methods supported

### DIFF
--- a/src/components/SquarePaymentForm.tsx
+++ b/src/components/SquarePaymentForm.tsx
@@ -188,6 +188,8 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
     if (keys.includes('googlePay')) {
       setGooglePayState(methods.googlePay === true ? 'ready' : 'unavailable');
     }
+
+    props.methodsSupported && props.methodsSupported(methods);
   }
 
   const paymentFormLoaded = () => {
@@ -226,7 +228,7 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
         cardNonceResponseReceived: props.cardNonceResponseReceived ? cardNonceResponseReceivedCallback : null, // handles missing callback error
         createPaymentRequest: props.createPaymentRequest,
         inputEventReceived: props.inputEventReceived,
-        methodsSupported: props.methodsSupported,
+        methodsSupported,
         paymentFormLoaded,
         shippingContactChanged: props.shippingContactChanged,
         shippingOptionChanged: props.shippingOptionChanged,
@@ -295,7 +297,7 @@ export const SquarePaymentForm: React.FC<Props> = (props: Props) => {
       return;
     }
     try {
-      const newPaymentForm = new SqPaymentForm(buildSqPaymentFormConfiguration({ methodsSupported, ...props }));
+      const newPaymentForm = new SqPaymentForm(buildSqPaymentFormConfiguration(props));
       newPaymentForm.build();
       setPaymentForm(newPaymentForm);
     } catch (error) {

--- a/src/components/__tests__/SquarePaymentForm.test.tsx
+++ b/src/components/__tests__/SquarePaymentForm.test.tsx
@@ -7,8 +7,9 @@ import { SquarePaymentForm } from '../SquarePaymentForm'
 
 describe('SquarePaymentForm', () => {
   let wrapper: any
-  var cardNonceResponseReceived = jest.fn()
-  var paymentFormLoaded = jest.fn()
+  const cardNonceResponseReceived = jest.fn()
+  const paymentFormLoaded = jest.fn()
+  const methodsSupportedCustom = jest.fn()
 
   beforeEach(() => {
     wrapper = shallow(
@@ -17,6 +18,7 @@ describe('SquarePaymentForm', () => {
         locationId={'test'}
         cardNonceResponseReceived={cardNonceResponseReceived}
         paymentFormLoaded={paymentFormLoaded}
+        methodsSupported={methodsSupportedCustom}
       />
     )
     wrapper.instance().renderSqPaymentForm = jest.fn()
@@ -88,20 +90,41 @@ describe('SquarePaymentForm', () => {
   })
 
   describe('methodsSupported', () => {
-    ;['applePay', 'googlePay', 'masterpass'].forEach(method => {
-      ;['ready', 'unavailable'].forEach(state => {
-        const key = `${method}State`
-        it(`should set ${key} = ${state}`, () => {
-          const instance = wrapper.instance()
-          const spy = jest.spyOn(instance, 'setState')
-          spy.mockClear()
-          instance.methodsSupported({ [method]: state === 'ready' ? true : false })
-          expect(spy.mock.calls.length).to.eql(1)
-          expect(instance.state[key]).to.eql(state)
-          spy.mockClear()
+
+    it('should coorectly set the component state for each method and state', () => {
+      ;['applePay', 'googlePay', 'masterpass'].forEach(method => {
+        ;['ready', 'unavailable'].forEach(state => {
+          const key = `${method}State`
+          it(`should set ${key} = ${state}`, () => {
+            const instance = wrapper.instance()
+            const spy = jest.spyOn(instance, 'setState')
+            spy.mockClear()
+            instance.methodsSupported({ [method]: state === 'ready' ? true : false })
+            expect(spy.mock.calls.length).to.eql(1)
+            expect(instance.state[key]).to.eql(state)
+            spy.mockClear()
+          })
         })
       })
     })
+
+    it('should also call the custom methodsSupported prop if supplied', () => {
+      ;['applePay', 'googlePay', 'masterpass'].forEach(method => {
+        ;['ready', 'unavailable'].forEach(state => {
+          const key = `${method}State`
+          it(`should set ${key} = ${state}`, () => {
+            const instance = wrapper.instance()
+            methodsSupportedCustom.mockClear()
+            const supported = state === 'ready' ? true : false;
+            instance.methodsSupported({ [method]: supported })
+            expect(methodsSupportedCustom.mock.calls.length).to.eql(1)
+            expect(methodsSupportedCustom.mock.calls[0][0]).to.eql({[method]: supported})
+            methodsSupportedCustom.mockClear()
+          })
+        })
+      })
+    })
+
   })
 
   describe('render', () => {

--- a/src/components/__tests__/SquarePaymentForm.test.tsx
+++ b/src/components/__tests__/SquarePaymentForm.test.tsx
@@ -118,7 +118,7 @@ describe('SquarePaymentForm', () => {
             const supported = state === 'ready' ? true : false;
             instance.methodsSupported({ [method]: supported })
             expect(methodsSupportedCustom.mock.calls.length).to.eql(1)
-            expect(methodsSupportedCustom.mock.calls[0][0]).to.eql({[method]: supported})
+            expect(methodsSupportedCustom.mock.calls[0][0]).to.eql({ [method]: supported })
             methodsSupportedCustom.mockClear()
           })
         })

--- a/src/components/__tests__/SquarePaymentForm.test.tsx
+++ b/src/components/__tests__/SquarePaymentForm.test.tsx
@@ -124,7 +124,6 @@ describe('SquarePaymentForm', () => {
         })
       })
     })
-
   })
 
   describe('render', () => {


### PR DESCRIPTION
Always call the default `methodsSupported` method even if a prop is supplied for a custom `methodsSupported`

This ensures that the context is as expected, with the various states like `applePayState` and `googlePayState` being set to 'unavailable' or 'ready', rather than remaining indefinitely on 'loading'. 

(Without this, the components like `<ApplePayButton />` will not behave as expected when a custom `methodsSupported` prop is supplied.)